### PR TITLE
add double write for durability (transaction log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.0.2] - 2025-04-16
+### Added
+- Transactional log (double write) mechanism to improve durability and ACID compliance
+- `Freelist` dirty flag to avoid unnecessary writes when no changes are made  
+  *(TODO: Optimize further by writing only affected pages)*
+- Configurable database options:
+    - File open mode
+    - Transaction log filename
+    - Recovery toggle to reapply the transaction log on restart
+
+### Changed
+- Switched from `mmap` to manual file read/write for better control over disk persistence
+
+### Fixed
+- Deadlock issue in write transactions
+
+## [0.0.1] - 2025-03-30
+- Initial release

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Project contains:
 - **Basic Cursor and Range Scanning:** Provides mechanisms to iterate over data ranges efficiently.
 - **View/Update Syntax Sugar:** Convenient API methods to simplify database interactions.
 - [x] **Blob Storage:** Supports for BLOBs.
-- [ ] **Copy on-write:** Support for copy-on-write for data consistency and recovery.
+- [x] ~~**Copy on-write:** Support for copy-on-write~~ **Double write** (last transaction log) for data consistency and recovery.
 - [ ] **Simple ORM:** Basic object-relational mapping layer for data structures.
 - [x] **Statistics:** Built-in statistics.
 

--- a/cmd/pirindb/main.go
+++ b/cmd/pirindb/main.go
@@ -21,7 +21,7 @@ func runServer(cfgFile string) {
 
 	logger := createLogger(config.Server.LogLevel)
 	storage.SetLogger(logger)
-	db, DBErr := storage.Open(config.DB.Filename, 0600)
+	db, DBErr := storage.Open(config.DB.Filename, nil)
 	if DBErr != nil {
 		fmt.Printf("Error opening database:\n  %v\n", DBErr)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.31.0
 )
 
 require (
@@ -53,6 +52,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/storage/blob_test.go
+++ b/storage/blob_test.go
@@ -27,7 +27,7 @@ func TestNewBlob(t *testing.T) {
 	closeTestDB(t, db)
 
 	// Now open created database
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
 	tx = db.Begin(true)
 
 	existingBlob, errRead := GetBlob(tx, pageNum)

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -33,7 +33,7 @@ func TestBucketInsertFindRemoveRandom(t *testing.T) {
 	closeTestDB(t, db)
 
 	// Reopen DB
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
 	var keysToRemove [][]byte
 
 	t.Log("test of all inserted items, and randomly choose items to remove")
@@ -80,7 +80,7 @@ func TestBucketInsertFindRemoveRandom(t *testing.T) {
 	closeTestDB(t, db)
 
 	// Reopen once again
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
 	err = db.View(func(tx *Tx) error {
 		bucket, _ := tx.GetBucket([]byte("foo"))
 		for _, k := range keysToRemove {
@@ -127,11 +127,13 @@ func BenchmarkBucketOperations(b *testing.B) {
 	const numEntries = 100_000
 	keys := make([][]byte, numEntries)
 	values := make([][]byte, numEntries)
+
+	db, err := Open(path, nil)
 	b.Cleanup(func() {
 		_ = os.Remove(path)
+		_ = os.Remove(db.dal.opts.TxLogPath)
 	})
 
-	db, err := Open(path, 0644)
 	require.NoError(b, err)
 	defer func() {
 		_ = db.Close()
@@ -209,7 +211,8 @@ func TestBucketInsertRandom(t *testing.T) {
 	require.NoError(t, err)
 	closeTestDB(t, db)
 
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
+	require.NoError(t, err)
 
 	err = db.View(func(tx *Tx) error {
 		bucket, _ := tx.GetBucket([]byte("foo"))

--- a/storage/db.go
+++ b/storage/db.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"os"
 	"sync"
 	"sync/atomic"
 )
@@ -31,8 +30,11 @@ type DBStat struct {
 	TxN           int                    // total number of started read transactions
 }
 
-func Open(path string, mode os.FileMode) (*DB, error) {
-	dal, err := NewDal(path, mode, 4096)
+func Open(path string, opts *Options) (*DB, error) {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+	dal, err := NewDal(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -113,4 +115,8 @@ func (db *DB) Stat() *DBStat {
 		TxN:           int(db.TxN.Load()),
 	}
 	return stat
+}
+
+func (db *DB) GetOptions() *Options {
+	return db.dal.opts
 }

--- a/storage/freelist_test.go
+++ b/storage/freelist_test.go
@@ -18,18 +18,20 @@ func TestFreelistWriteRead(t *testing.T) {
 		freelist.releasedPages[i] = uint64(i)
 	}
 	// Flush it to the disk
+	freelist.dirty = true
 	err := WriteFreelist(db.dal, freelist)
 	closeTestDB(t, db)
 
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
 	// Truncated releasedPages
 	freelist.releasedPages = db.dal.freelist.releasedPages[:3000]
 	// Flush to the disk once again
+	freelist.dirty = true
 	err = WriteFreelist(db.dal, freelist)
 	require.NoError(t, err)
 	closeTestDB(t, db)
 
-	db = openTestDB(t, filename)
+	db = openTestDB(t, filename, nil)
 	require.NoError(t, err)
 	require.True(t, reflect.DeepEqual(freelist.freelistPages, db.dal.freelist.freelistPages))
 	require.True(t, reflect.DeepEqual(freelist.releasedPages, db.dal.freelist.releasedPages))

--- a/storage/options.go
+++ b/storage/options.go
@@ -1,0 +1,39 @@
+package storage
+
+import "os"
+
+type Options struct {
+	FileMode       os.FileMode
+	PageSize       uint64
+	EnableRecovery bool
+	TxLogPath      string
+}
+
+func DefaultOptions() *Options {
+	return &Options{
+		FileMode:       0600,
+		PageSize:       BTreePageSize,
+		EnableRecovery: true,
+		TxLogPath:      "", // default to db basename + ".tlog"
+	}
+}
+
+func (o *Options) WithRecovery(enable bool) *Options {
+	o.EnableRecovery = enable
+	return o
+}
+
+func (o *Options) WithPageSize(pageSize uint64) *Options {
+	o.PageSize = pageSize
+	return o
+}
+
+func (o *Options) WithTxLogPath(path string) *Options {
+	o.TxLogPath = path
+	return o
+}
+
+func (o *Options) WithFileMode(mode os.FileMode) *Options {
+	o.FileMode = mode
+	return o
+}

--- a/storage/page.go
+++ b/storage/page.go
@@ -17,3 +17,22 @@ func (p *Page) Clear() {
 		p.Data[i] = 0
 	}
 }
+
+func (p *Page) GetPageType() string {
+	if len(p.Data) == 0 {
+		return "Unknown"
+	}
+
+	switch p.Data[0] {
+	case MetaPage:
+		return "Meta"
+	case FreeListPage:
+		return "Freelist"
+	case NodePage:
+		return "Node"
+	case BlobPage:
+		return "Blob"
+	default:
+		return "Unknown"
+	}
+}

--- a/storage/test_helpers.go
+++ b/storage/test_helpers.go
@@ -27,7 +27,7 @@ func TempFileName(suffix string) string {
 func createTestDB(t *testing.T) (*DB, string) {
 	tempFilename := TempFileName(".db")
 
-	db, err := Open(tempFilename, 0644)
+	db, err := Open(tempFilename, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,12 +37,13 @@ func createTestDB(t *testing.T) (*DB, string) {
 			t.Fatal(err)
 		}
 		_ = os.Remove(tempFilename)
+		_ = os.Remove(db.dal.opts.TxLogPath)
 	})
 	return db, tempFilename
 }
 
-func openTestDB(t *testing.T, filename string) *DB {
-	db, err := Open(filename, 0644)
+func openTestDB(t *testing.T, filename string, opts *Options) *DB {
+	db, err := Open(filename, opts)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 	return db

--- a/storage/tx_log.go
+++ b/storage/tx_log.go
@@ -1,0 +1,193 @@
+package storage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"os"
+	"sync"
+)
+
+// TxLog header map
+// 0            8                    14
+// +------------+------------+--------+
+// | Num Pages  | Page Size  |  CRC   |
+// |  uint8     |  uint16    | uint32 |
+// +------------+------------+--------+
+
+// TxLog pages map
+// 0         8              16             page size + header
+// +---------+---------------+--------------------+ ... N pages
+// | offset  | Page Number   |      Page data     |
+// | uint64  |   uint64      |       uint8[]      |
+// +---------+---------------+--------------------+
+
+const (
+	txLogNumPagesSize   = UInt64Size
+	txLogPageSizeBytes  = UInt16Size
+	txLogCRCSize        = UInt32Size
+	txLogHeaderSize     = txLogNumPagesSize + txLogPageSizeBytes + txLogCRCSize
+	txLogPageOffsetSize = UInt64Size
+	txLogPageNumberSize = UInt64Size
+	txLogPageHeaderSize = txLogPageOffsetSize + txLogPageNumberSize
+
+	txLogNumPages = 0
+	txLogPageSize = txLogNumPages + txLogNumPagesSize
+	txLogCRC      = txLogPageSize + txLogPageSizeBytes
+
+	txLogPageOffset = 0
+	txLogPageNumber = txLogPageOffset + txLogPageOffsetSize
+)
+
+type TxLog struct {
+	lock     sync.Mutex
+	file     *os.File
+	numPages int
+	pageSize int
+	crc      hash.Hash32
+	table    *crc32.Table
+	active   bool
+}
+
+type PageRecoveryCallback func(offset uint64, page *Page) error
+
+func NewTxLog(filename string, mode os.FileMode) *TxLog {
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, mode)
+	if err != nil {
+		logger.Error("Failed to open log file", "filename", filename, "error", err)
+	}
+	return &TxLog{
+		lock:     sync.Mutex{},
+		file:     file,
+		pageSize: BTreePageSize,
+		table:    crc32.MakeTable(crc32.IEEE),
+	}
+}
+
+func (txlog *TxLog) enter() {
+	err := txlog.file.Truncate(0)
+	_, err = txlog.file.Seek(txLogHeaderSize, 0)
+	txlog.active = true
+	txlog.crc = crc32.New(txlog.table)
+	txlog.numPages = 0
+	if err != nil {
+		return
+	}
+}
+
+func (txlog *TxLog) leave() error {
+	defer func() {
+		txlog.active = false
+	}()
+	_, err := txlog.file.Seek(0, 0)
+	header := make([]byte, txLogHeaderSize)
+	binary.LittleEndian.PutUint64(header[txLogNumPages:], uint64(txlog.numPages))
+	binary.LittleEndian.PutUint16(header[txLogPageSize:], uint16(txlog.pageSize))
+	binary.LittleEndian.PutUint32(header[txLogCRC:], txlog.crc.Sum32())
+	_, err = txlog.file.Write(header)
+	if err != nil {
+		return err
+	}
+	err = txlog.file.Sync()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (txlog *TxLog) writePage(offset uint64, page *Page) error {
+	data := make([]byte, txLogPageHeaderSize)
+	binary.LittleEndian.PutUint64(data, offset)
+	binary.LittleEndian.PutUint64(data[txLogPageNumber:], page.PageNumber)
+	_, err := txlog.file.Write(data)
+	if err != nil {
+		return err
+	}
+	_, _ = txlog.crc.Write(data)
+	_, err = txlog.file.Write(page.Data)
+	if err != nil {
+		return err
+	}
+	_, _ = txlog.crc.Write(page.Data)
+	txlog.numPages++
+	return nil
+}
+
+func (txlog *TxLog) With(fn func() error) error {
+	txlog.lock.Lock()
+	defer txlog.lock.Unlock()
+
+	txlog.enter()
+	defer txlog.leave()
+
+	return fn()
+}
+
+func (txlog *TxLog) Recover(callback PageRecoveryCallback) error {
+	txlog.lock.Lock()
+	defer txlog.lock.Unlock()
+
+	info, err := txlog.file.Stat()
+	if err != nil {
+		return err
+	}
+
+	totalSize := info.Size()
+	if totalSize == 0 {
+		return nil
+	}
+
+	// Read header
+	header := make([]byte, 14)
+	_, err = txlog.file.ReadAt(header, 0)
+	if err != nil {
+		return err
+	}
+
+	numPages := int(binary.LittleEndian.Uint64(header[txLogNumPages:]))
+	pageSize := int(binary.LittleEndian.Uint16(header[txLogPageSize:]))
+	expectedCRC := binary.LittleEndian.Uint32(header[txLogCRC:])
+
+	// Read rest of the file
+
+	dataSize := totalSize - txLogHeaderSize
+	if dataSize <= 0 {
+		return nil
+	}
+	data := make([]byte, dataSize)
+	_, err = txlog.file.ReadAt(data, txLogHeaderSize)
+	if err != nil {
+		return err
+	}
+
+	// Validate CRC
+	crc := crc32.New(txlog.table)
+	_, _ = crc.Write(data)
+	actualCRC := crc.Sum32()
+	if actualCRC != expectedCRC {
+		return fmt.Errorf("CRC mismatch: expected %08x, got %08x", expectedCRC, actualCRC)
+	}
+
+	// Process each (offset, page)
+	cursor := 0
+	for i := 0; i < numPages; i++ {
+		offset := binary.LittleEndian.Uint64(data[cursor : cursor+txLogPageOffsetSize])
+		cursor += txLogPageOffsetSize
+		pageNum := binary.LittleEndian.Uint64(data[cursor : cursor+txLogPageNumberSize])
+		cursor += txLogPageNumberSize
+
+		page := &Page{
+			PageNumber: pageNum, // optional
+			Data:       make([]byte, pageSize),
+		}
+		copy(page.Data, data[cursor:cursor+pageSize])
+		cursor += pageSize
+
+		if err = callback(offset, page); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/storage/tx_log_test.go
+++ b/storage/tx_log_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func Test_Recovery_AfterSimulatedCrash(t *testing.T) {
+	pattern := []byte("1234")
+	checkFunc := func(db *DB) error {
+		return db.View(func(tx *Tx) error {
+			usersBucket, err := tx.GetBucket([]byte("users"))
+			if err != nil {
+				return err
+			}
+			value, found := usersBucket.Get([]byte("id"))
+			if !found {
+				return fmt.Errorf("found id key, but should not be")
+			}
+			if !reflect.DeepEqual(value, pattern) {
+				return fmt.Errorf("%v != %v", value, pattern)
+			}
+			t.Logf("read key from users bucket: %s", string(value))
+			return nil
+		})
+	}
+
+	db, filename := createTestDB(t)
+	tx := db.Begin(true)
+	bucket, err := tx.CreateBucketIfNotExists([]byte("users"))
+	require.NoError(t, err)
+	err = bucket.Put([]byte("id"), []byte("1234"))
+	require.NoError(t, err)
+	// Inject failure after txLog writes are done
+	db.dal.beforeSetPageHook = func(p *Page) error {
+		if !db.dal.txLog.active {
+			return fmt.Errorf("unable to write pages to db")
+		}
+		return nil
+	}
+
+	err = tx.Commit() // This will crash
+	require.Error(t, err)
+	t.Logf("trying to fetch id key from users bucket")
+	err = checkFunc(db)
+	require.Error(t, err)
+	db.Close()
+
+	t.Log("reopen DB without recovery")
+	db = openTestDB(t, filename, DefaultOptions().WithRecovery(false))
+	err = checkFunc(db)
+	t.Log(err)
+	require.Error(t, err)
+	db.Close()
+
+	t.Log("reopen DB with recovery")
+	db = openTestDB(t, filename, DefaultOptions().WithRecovery(true))
+	err = checkFunc(db)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- Added transaction log (double write) for durability. On each transaction, a physical log is written with the page offset and page data. On restart, if the recovery flag is set (default), the transaction log is applied.
- Added configuration options to the database.
- Introduced a dirty flag for the freelist to avoid writing it unless it has changed.
- Fixed deadlock issues in `tx.Commit`.
